### PR TITLE
Add adaptive Groq summarizer chunking and debug controls

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -1,0 +1,9 @@
+Please refer README.md to understand the project.
+
+Always uses the virtual environment in .venv.
+
+Always use uv.
+
+If you are on the main branch, create a new branch for any code changes.
+
+For verbose Groq summarizer diagnostics, set `BIG_MOVES_DEBUG_PROMPTS=true` in your `.env` (project root or global). Leave unset/false for normal output. Logging is gated by this flag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [Unreleased]
+- Add adaptive chunking for Groq summarization using per-model context windows (dynamic fetch + static hints).
+- Respect `.env` for `BIG_MOVES_DEBUG_PROMPTS` and gate prompt-level logging; added README/Agents notes for usage.
+- Fetch Groq model hints via `requests` (per Groq docs) with graceful fallback to static table.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ big-moves config set --all
 
 ```
 
+Optional debug logging for summarizer prompts:
+
+```bash
+# In your .env (project cwd or global config):
+BIG_MOVES_DEBUG_PROMPTS=true
+```
+When enabled, the app logs model hint selection, budgets, and prompts (stdout). Leave unset/false for normal runs.
+
 Analyze US listed stocks: 
 
 
@@ -56,4 +64,3 @@ big-moves run <TICKER> [OPTIONS]
 ```bash
  big-moves run ONDS --max_segments 6 --min_points 6 --detailed_news --big_move_threshold 30.0  
 ```
-

--- a/src/big_moves/ai_summarizer.py
+++ b/src/big_moves/ai_summarizer.py
@@ -27,21 +27,129 @@ try:
 except Exception as exc:
     raise ImportError("The 'groq' package is required. Install it with 'pip install groq'.") from exc
 
-
 from .config import find_and_load_env
 
 logger = logging.getLogger(__name__)
 
-# Try to load from standard candidate paths and record where we loaded env from
+MAX_ITEMS_PER_CHUNK = 30  # legacy cap; adaptive chunking will be used instead
+MAX_PROMPT_CHARS = 6000
+FINAL_PROMPT_CHARS = 8000
+
+# Load env before reading the debug flag so .env values apply
 _CANDIDATES, _LOADED_ENV = find_and_load_env()
-if _LOADED_ENV:
-    logger.debug('Loaded env from %s', _LOADED_ENV)
-else:
-    logger.debug('No env file found in candidates: %s', _CANDIDATES)
+DEBUG_PROMPTS = os.getenv("BIG_MOVES_DEBUG_PROMPTS", "").lower() in ("1", "true", "yes")
+
+# If prompt debugging is enabled, ensure we have a console handler and DEBUG level.
+if DEBUG_PROMPTS:
+    logger.setLevel(logging.DEBUG)
+    if not logger.handlers:
+        _handler = logging.StreamHandler()
+        _handler.setLevel(logging.DEBUG)
+        _handler.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s"))
+        logger.addHandler(_handler)
+    if _LOADED_ENV:
+        logger.debug("Loaded env from %s", _LOADED_ENV)
+    else:
+        logger.debug("No env file found in candidates: %s", _CANDIDATES)
+
+# Model-aware budgets (char/4 heuristic). Base hints derived from Groq model list.
+STATIC_MODEL_HINTS = {
+    "qwen/qwen3-32b": {"context": 131072, "max_completion": 40960},
+    "moonshotai/kimi-k2-instruct": {"context": 131072, "max_completion": 16384},
+    "llama-3.3-70b-versatile": {"context": 131072, "max_completion": 32768},
+    "canopylabs/orpheus-v1-english": {"context": 4000, "max_completion": 50000},
+    "meta-llama/llama-4-scout-17b-16e-instruct": {"context": 131072, "max_completion": 8192},
+    "meta-llama/llama-4-maverick-17b-128e-instruct": {"context": 131072, "max_completion": 8192},
+    "openai/gpt-oss-safeguard-20b": {"context": 131072, "max_completion": 65536},
+    "meta-llama/llama-guard-4-12b": {"context": 131072, "max_completion": 1024},
+    "whisper-large-v3": {"context": 448, "max_completion": 448},
+    "openai/gpt-oss-20b": {"context": 131072, "max_completion": 65536},
+    "canopylabs/orpheus-arabic-saudi": {"context": 4000, "max_completion": 50000},
+    "meta-llama/llama-prompt-guard-2-22m": {"context": 512, "max_completion": 512},
+    "moonshotai/kimi-k2-instruct-0905": {"context": 262144, "max_completion": 16384},
+    "llama-3.1-8b-instant": {"context": 131072, "max_completion": 131072},
+    "groq/compound-mini": {"context": 131072, "max_completion": 8192},
+    "whisper-large-v3-turbo": {"context": 448, "max_completion": 448},
+    "groq/compound": {"context": 131072, "max_completion": 8192},
+    "openai/gpt-oss-120b": {"context": 131072, "max_completion": 65536},
+    "allam-2-7b": {"context": 4096, "max_completion": 4096},
+    "meta-llama/llama-prompt-guard-2-86m": {"context": 512, "max_completion": 512},
+}
+DEFAULT_CONTEXT = 8000
+DEFAULT_COMPLETION_BUDGET = 400  # tokens reserved for model reply
+HEADER_OVERHEAD = 80  # rough tokens for prompt scaffolding
 
 
-def _build_prompt_from_df(news_df: pd.DataFrame) -> str:
-    # prefer Title and Summary/Content columns
+def _fetch_groq_model_hints_from_api() -> dict:
+    """Attempt to fetch model context info from Groq API. Falls back silently on error."""
+    api_key = os.environ.get("GROQ_API_KEY")
+    if not api_key:
+        return {}
+    url = os.environ.get("GROQ_API_URL", "https://api.groq.com/openai/v1/models")
+    try:
+        import requests
+        resp = requests.get(
+            url,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            timeout=10,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        hints = {}
+        for m in data.get("data", []):
+            mid = m.get("id")
+            ctx_win = m.get("context_window") or m.get("context_length") or m.get("max_context_length")
+            max_comp = m.get("max_completion_tokens")
+            if mid and ctx_win:
+                hints[mid] = {"context": int(ctx_win), "max_completion": int(max_comp) if max_comp else None}
+        if DEBUG_PROMPTS:
+            logger.debug("Fetched %s model hints from Groq API", len(hints))
+        return hints
+    except Exception as exc:
+        if DEBUG_PROMPTS:
+            logger.debug("Groq model fetch failed: %s", exc)
+        return {}
+
+
+def _select_hints_for_model(model_name: str) -> dict:
+    model_name = model_name or ""
+    # Try dynamic fetch (cached per process)
+    global _DYNAMIC_MODEL_HINTS
+    try:
+        _DYNAMIC_MODEL_HINTS
+    except NameError:
+        _DYNAMIC_MODEL_HINTS = _fetch_groq_model_hints_from_api()
+
+    # exact match first
+    if model_name in _DYNAMIC_MODEL_HINTS:
+        return _DYNAMIC_MODEL_HINTS[model_name]
+    if model_name in STATIC_MODEL_HINTS:
+        return STATIC_MODEL_HINTS[model_name]
+
+    # substring fallback
+    lname = model_name.lower()
+    for mid, hint in _DYNAMIC_MODEL_HINTS.items():
+        if mid.lower() in lname or lname in mid.lower():
+            return hint
+    for mid, hint in STATIC_MODEL_HINTS.items():
+        if mid.lower() in lname or lname in mid.lower():
+            return hint
+
+    return {"context": DEFAULT_CONTEXT, "max_completion": DEFAULT_COMPLETION_BUDGET}
+
+
+def _estimate_tokens(text: str) -> int:
+    # crude heuristic: approx 4 chars per token
+    return max(1, (len(text) + 3) // 4)
+
+def _build_prompt_from_df(
+    news_df: pd.DataFrame,
+    max_items: int = MAX_ITEMS_PER_CHUNK,
+    max_chars: int = MAX_PROMPT_CHARS,
+) -> str:
     parts = []
     if news_df is None or news_df.empty:
         return ""
@@ -59,7 +167,18 @@ def _build_prompt_from_df(news_df: pd.DataFrame) -> str:
             seg += f" : {snippet}"
         parts.append(seg)
 
+    if len(parts) > max_items:
+        keep_each_side = max_items // 2
+        parts = parts[:keep_each_side] + ["... (truncated) ..."] + parts[-keep_each_side:]
+
     joined = '\n'.join(parts)
+
+    if len(joined) > max_chars:
+        joined = joined[:max_chars]
+        if '\n' in joined:
+            joined = joined.rsplit('\n', 1)[0]
+        joined += "\n... (truncated to fit model context)"
+
     prompt = (
         "You are a concise financial news summarization assistant. "
         "Given a list of dated headlines (with optional short snippets), produce a brief, neutral summary "
@@ -68,9 +187,7 @@ def _build_prompt_from_df(news_df: pd.DataFrame) -> str:
         f"{joined}\n\n"
         "Return only the summary, no commentary or attribution."
     )
-    # logger.debug("Built prompt : ", prompt)
     return prompt
-
 
 def _call_groq(prompt: str, max_tokens: int = 1000) -> str:
     api_key = os.getenv('GROQ_API_KEY')
@@ -81,11 +198,18 @@ def _call_groq(prompt: str, max_tokens: int = 1000) -> str:
 
     # Create client and call completions API using the official SDK
     from groq import Groq
-        # client = groq.Client(api_key=api_key)
 
-    # Client automatically uses the GROQ_API_KEY environment variable
     client = Groq(api_key=api_key)
-    
+
+    logger.debug(
+        "Groq request: model=%s, max_tokens=%s, prompt_chars=%s",
+        model,
+        max_tokens,
+        len(prompt),
+    )
+    if DEBUG_PROMPTS:
+        logger.debug("Groq prompt:\n%s", prompt)
+
     chat_completion = client.chat.completions.create(
         messages=[
             {
@@ -94,12 +218,16 @@ def _call_groq(prompt: str, max_tokens: int = 1000) -> str:
             }
         ],
         model=model,
+        max_tokens=max_tokens,
     )
-    
-    # This print statement will only run after the full response is received.
+
     return chat_completion.choices[0].message.content
 
-
+def _summarize_chunk(news_df: pd.DataFrame, max_tokens: int) -> str:
+    prompt = _build_prompt_from_df(news_df)
+    if not prompt:
+        return ""
+    return _call_groq(prompt, max_tokens=max_tokens).strip()
 
 def summarize_news_df(news_df: pd.DataFrame, max_tokens: int = 150) -> str:
     """Summarize a news DataFrame using Groq.ai.
@@ -109,36 +237,107 @@ def summarize_news_df(news_df: pd.DataFrame, max_tokens: int = 150) -> str:
     if news_df is None or news_df.empty:
         return ""
 
-    prompt = _build_prompt_from_df(news_df)
     try:
-        # Return whatever the model produced (no additional truncation here)
-        return _call_groq(prompt, max_tokens=max_tokens).strip()
+        model = os.getenv('GROQ_MODEL', 'groq/compound-mini')
+        hints = _select_hints_for_model(model)
+        context_window = hints.get("context", DEFAULT_CONTEXT)
+        completion_budget = hints.get("max_completion") or DEFAULT_COMPLETION_BUDGET
+        prompt_budget_map = max(int((context_window - completion_budget) * 0.65), 800)
+        prompt_budget_reduce = max(int((context_window - completion_budget) * 0.75), 1000)
+        if DEBUG_PROMPTS:
+            logger.debug(
+                "Using model=%s context_window=%s, map_budget=%s, reduce_budget=%s, completion_budget=%s (hinted=%s)",
+                model,
+                context_window,
+                prompt_budget_map,
+                prompt_budget_reduce,
+                completion_budget,
+                hints,
+            )
+
+        # sort chronologically so chunk summaries preserve flow
+        news_df = news_df.sort_values('Date', ascending=True)
+
+        # Adaptive chunking based on token budget (char/4 heuristic)
+        chunk_summaries = []
+        start_idx = 0
+        tokens_used = 0
+        token_budget = prompt_budget_map - HEADER_OVERHEAD
+
+        for idx, (_, row) in enumerate(news_df.iterrows()):
+            date = row.get('Date')
+            title = row.get('Title') or ''
+            src = row.get('Source') or ''
+            snippet = row.get('Summary') or row.get('Content') or ''
+            seg = f"{date.strftime('%Y-%m-%d') if hasattr(date, 'strftime') else date} - {title}"
+            if src:
+                seg += f" ({src})"
+            if snippet:
+                seg += f" : {snippet}"
+            seg_tokens = _estimate_tokens(seg)
+
+            # If adding this segment would exceed budget and we already have some rows, flush the chunk.
+            if tokens_used + seg_tokens > token_budget and start_idx < idx:
+                chunk = news_df.iloc[start_idx:idx]
+                logger.debug(
+                    "Summarizing chunk %s (rows %s-%s of %s, est_tokens=%s)",
+                    len(chunk_summaries) + 1,
+                    start_idx,
+                    idx - 1,
+                    len(news_df),
+                    tokens_used,
+                )
+                chunk_summary = _summarize_chunk(chunk, max_tokens=max_tokens)
+                if chunk_summary:
+                    chunk_summaries.append(chunk_summary)
+                start_idx = idx
+                tokens_used = 0
+
+            tokens_used += seg_tokens
+
+        # Handle the tail chunk
+        if start_idx < len(news_df):
+            chunk = news_df.iloc[start_idx:]
+            logger.debug(
+                "Summarizing chunk %s (rows %s-%s of %s, est_tokens=%s)",
+                len(chunk_summaries) + 1,
+                start_idx,
+                len(news_df) - 1,
+                len(news_df),
+                tokens_used,
+            )
+            chunk_summary = _summarize_chunk(chunk, max_tokens=max_tokens)
+            if chunk_summary:
+                chunk_summaries.append(chunk_summary)
+
+        if not chunk_summaries:
+            return ""
+
+        if len(chunk_summaries) == 1:
+            return chunk_summaries[0]
+
+        # Combine chunk summaries into a final concise narrative
+        bullets = "\n".join(f"- {s}" for s in chunk_summaries)
+        logger.debug("Combining %s chunk summaries into final prompt", len(chunk_summaries))
+        final_prompt = (
+            "You are a concise financial news summarization assistant. "
+            "Combine the following chunk summaries into a single 2-3 sentence narrative that captures the main drivers, "
+            "themes, and timeline. Preserve chronological flow if relevant.\n\n"
+            "Chunk summaries:\n"
+            f"{bullets}\n\n"
+            "Return only the combined summary, no commentary or attribution."
+        )
+        reduce_max_chars = int(prompt_budget_reduce * 4)
+        if len(final_prompt) > reduce_max_chars:
+            final_prompt = final_prompt[:reduce_max_chars]
+            if '\n' in final_prompt:
+                final_prompt = final_prompt.rsplit('\n', 1)[0]
+            final_prompt += "\n... (truncated to fit model context)"
+        logger.debug("Final prompt chars=%s (budget chars=%s)", len(final_prompt), reduce_max_chars)
+        if DEBUG_PROMPTS:
+            logger.debug("Final Groq prompt:\n%s", final_prompt)
+
+        return _call_groq(final_prompt, max_tokens=max_tokens).strip()
     except Exception as e:
         logger.warning("Groq.ai summarization failed: %s.", e)
         raise
-        # local fallback: build date-prefixed entries and show up to 5 head + 5 tail
-        # parts = []
-        # for _, row in news_df.iterrows():
-        #     date = row.get('Date')
-        #     date_str = date.strftime('%Y-%m-%d') if hasattr(date, 'strftime') else str(date)
-        #     title = row.get('Title') or ''
-        #     src = row.get('Source') or ''
-        #     snippet = row.get('Summary') or row.get('Content') or ''
-        #     seg = f"{date_str} - {title}"
-        #     if src:
-        #         seg += f" ({src})"
-        #     if snippet:
-        #         seg += f" : {snippet}"
-        #     parts.append(seg)
-        # if not parts:
-        #     return ""
-        # # If more than 10 items, show first 5 and last 5 with an ellipsis in between
-        # if len(parts) > 10:
-        #     display_parts = parts[:5] + ['...'] + parts[-5:]
-        # else:
-        #     display_parts = parts
-        # joined = ' '.join(display_parts)
-        # # truncate to max_tokens characters, attempting to cut at a sentence boundary
-        # if len(joined) > max_tokens:
-        #     return (joined[:max_tokens].rsplit('.', 1)[0] + '...')
-        # return joined


### PR DESCRIPTION
**Summary :** 

* Implement model-aware adaptive chunking for Groq summarization using per-model context windows (dynamic fetch + static hints).

* Respect BIG_MOVES_DEBUG_PROMPTS from .env before configuring logging; add instructions to README and Agents.

* Fetch Groq model hints via requests (per Groq docs), falling back to static table if the API isn’t reachable.

* Add CHANGELOG.md with current changes (Unreleased).

**Testing:**

* Manual runs (summarizer with different models / debug flag).