### PR TITLE
Review branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Cap Groq completion budget to max(10% of context, default) and 2048 tokens to avoid negative prompt budgets.
 - Add adaptive chunking for Groq summarization using per-model context windows (dynamic fetch + static hints).
 - Respect `.env` for `BIG_MOVES_DEBUG_PROMPTS` and gate prompt-level logging; added README/Agents notes for usage.
 - Fetch Groq model hints via `requests` (per Groq docs) with graceful fallback to static table.

--- a/src/big_moves/ai_summarizer.py
+++ b/src/big_moves/ai_summarizer.py
@@ -241,7 +241,13 @@ def summarize_news_df(news_df: pd.DataFrame, max_tokens: int = 150) -> str:
         model = os.getenv('GROQ_MODEL', 'groq/compound-mini')
         hints = _select_hints_for_model(model)
         context_window = hints.get("context", DEFAULT_CONTEXT)
-        completion_budget = hints.get("max_completion") or DEFAULT_COMPLETION_BUDGET
+        hinted_max_completion = hints.get("max_completion") or DEFAULT_COMPLETION_BUDGET
+        # Reserve at least 10% of the context for completion, capped at 2048 tokens and the hinted max.
+        completion_budget = min(
+            hinted_max_completion,
+            2048,
+            max(int(context_window * 0.10), DEFAULT_COMPLETION_BUDGET),
+        )
         prompt_budget_map = max(int((context_window - completion_budget) * 0.65), 800)
         prompt_budget_reduce = max(int((context_window - completion_budget) * 0.75), 1000)
         if DEBUG_PROMPTS:


### PR DESCRIPTION
Fixes #12

- Reserve completion budget to max(10% of context, default) capped at 2048 and hinted max.
- Tested manually
